### PR TITLE
Show the polling rate for graphics tables

### DIFF
--- a/evhz.c
+++ b/evhz.c
@@ -94,7 +94,7 @@ int main(int argc, char *argv[]) {
 					continue;
 				}
 
-				if(event.type == EV_REL) {
+				if(event.type == EV_REL || event.type == EV_ABS) {
 					double time;
 					int hz;
 


### PR DESCRIPTION
It's not just mice that people change the polling rate on, they also do it on graphics/wacom tables. This change should also show the rate for touch screens. Which some might find useful.